### PR TITLE
ignore frames without data

### DIFF
--- a/sdmmc_from_spi.py
+++ b/sdmmc_from_spi.py
@@ -370,6 +370,8 @@ class SdmmcFromSpiAnalyzer(HighLevelAnalyzer):
         self.state = SdioState()
 
     def decode(self, data):
+        if not "mosi" in data.data:
+            return
         info = self.state.add_byte(
             data.data["mosi"], data.start_time, data.end_time
         )


### PR DESCRIPTION
Sometimes `data.data` is empy and causes the analyzer to crash. This pr adds a check to ignore empty frames